### PR TITLE
fix: if the volume wasn't set, do not apply it

### DIFF
--- a/app/src/main/java/com/chooloo/www/callmanager/ui/activity/OngoingCallActivity.java
+++ b/app/src/main/java/com/chooloo/www/callmanager/ui/activity/OngoingCallActivity.java
@@ -773,7 +773,7 @@ public class OngoingCallActivity extends AbsThemeActivity implements DialpadFrag
         CountDownTimer mTimer = null;
         boolean mIsRejecting = true;
 
-        int oldVolume;
+        Integer oldVolume;
 
         private void setData(long millisInFuture, boolean isRejecting) {
             mIsRejecting = isRejecting;
@@ -832,7 +832,7 @@ public class OngoingCallActivity extends AbsThemeActivity implements DialpadFrag
         }
 
         private void finalEndCommonMan() {
-            mAudioManager.setStreamVolume(AudioManager.STREAM_RING, oldVolume, 0);
+            if(oldVolume != null) mAudioManager.setStreamVolume(AudioManager.STREAM_RING, oldVolume, 0);
             removeOverlay();
         }
     }


### PR DESCRIPTION
( fixes #28 ) when calls are ended, the volume is reset to the previous volume -- but only when timers are used. when timers aren't used, the volume is *still* reset to 0 (oldVolume's default value).
the fix could be to make oldVolume nullable, and then check to see if it's set. 

this might not be the best way to fix it - I wouldn't even construct the timer if you aren't going to use it, but I think this change follows how things have been coded so far.