### PR TITLE
Fix ConstraintSet for OngoingCallActivity

### DIFF
--- a/app/src/main/res/layout/correction_overlay_reject_call_options.xml
+++ b/app/src/main/res/layout/correction_overlay_reject_call_options.xml
@@ -65,6 +65,7 @@
         app:srcCompat="@drawable/ic_sms_black_24dp" />
 
     <TextView
+        android:id="@+id/reject_sms"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginBottom="8dp"
@@ -92,6 +93,7 @@
         app:srcCompat="@drawable/ic_clear_black_24dp" />
 
     <TextView
+        android:id="@+id/cancel_btn"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginBottom="8dp"

--- a/app/src/main/res/layout/overlay_reject_call_options.xml
+++ b/app/src/main/res/layout/overlay_reject_call_options.xml
@@ -54,6 +54,7 @@
         app:srcCompat="@drawable/ic_sms_black_24dp" />
 
     <TextView
+        android:id="@+id/reject"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginEnd="4dp"
@@ -81,6 +82,7 @@
         app:srcCompat="@drawable/ic_clear_black_24dp" />
 
     <TextView
+        android:id="@+id/cancel_btn"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginEnd="8dp"


### PR DESCRIPTION
Fixes the crash because of in ConstraintLayout all childs must have an id's when using in ConstraintSet