### PR TITLE
fix edit & info actions in contact popup

### DIFF
--- a/app/src/main/java/com/chooloo/www/callmanager/cursorloader/ContactsCursorLoader.java
+++ b/app/src/main/java/com/chooloo/www/callmanager/cursorloader/ContactsCursorLoader.java
@@ -29,7 +29,7 @@ import static android.provider.ContactsContract.Contacts;
 public class ContactsCursorLoader extends CursorLoader {
 
     // Columns
-    public static String COLUMN_ID = Contacts._ID;
+    public static String COLUMN_ID = Phone.CONTACT_ID;
     public static String COLUMN_NAME = Contacts.DISPLAY_NAME_PRIMARY;
     public static String COLUMN_THUMBNAIL = Contacts.PHOTO_THUMBNAIL_URI;
     public static String COLUMN_NUMBER = Phone.NUMBER;


### PR DESCRIPTION
fixes #83 

android has a fairly complex system to maintain contacts. Here's what I know so far:

- `RawContacts` table stores the actual contacts
- `Data` table stores contact data
- `Contacts` table stores contacts after aggregation of `RawContacts` items using `Data` items (see [here][1])

These tables are connected via keys:

```
RawContacts.CONTACT_ID => Contacts._ID
Data.RAW_CONTACT_ID => RawContacts._ID
Data.CONTACT_ID => Contacts._ID
```

`CommonDataKinds.Phone` is a utility class for data representing a telephone number and `CommonDataKinds.Phone` references original contact's `Contacts._ID`.

Since `ContactsCursorLoader` queries on `Phone.CONTENT_URI` instead of `Contacts.CONTENT_URI`, using `Contacts._ID` directly returns `Phone._ID` values.

https://stackoverflow.com/a/23170037/1343488
https://stackoverflow.com/a/35695331/1343488

[1]: https://developer.android.com/guide/topics/providers/contacts-provider.html#ContactBasics
